### PR TITLE
bump to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ inputs:
     description: 'The name or ID of a space within which this command will be executed. If omitted, the default space will be used.'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Bumps the action to use node16 rather than node12 as per: [GitHub Depreciation Notice](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) 