### PR TITLE
chore: Fix API key used for integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       id: npm_tests
       env:
         OCTOPUS_TEST_URL: ${{ env.SERVER_URL }}
-        OCTOPUS_TEST_APIKEY: ${{ env.ADMIN_API_KEY }}
+        OCTOPUS_TEST_API_KEY: ${{ env.ADMIN_API_KEY }}
       run: npm run all
 
     - name: Test Report


### PR DESCRIPTION
PRs created by dependabot security updates are [failing on the integration tests](https://github.com/OctopusDeploy/run-runbook-action/actions/runs/7456449763/job/20287986681?pr=339) with an error "The API key you provided was not valid. Please double-check your API key and try again. For instructions on finding your API key, please visit: https://oc.to/ApiKey". I _think_ this is because the environment variable for the API key being passed through to the tests is wrong, although I really don't know why the normal PR tests work 🤷.

This PR sends through the right environment variable, hopefully this resolves the issue.