### PR TITLE
Pin version of SQL Server for integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       sqlserver:
-        image: mcr.microsoft.com/mssql/server:2019-latest
+        image: mcr.microsoft.com/mssql/server:2019-CU27-ubuntu-20.04
         env:
           ACCEPT_EULA: Y
           SA_PASSWORD: ${{ env.SA_PASSWORD }}


### PR DESCRIPTION
A new version of [SQL Server 2019 - Cumulative Update 28](https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2019/cumulativeupdate28) has https://github.com/microsoft/mssql-docker/issues/892. This caused our integration tests to fail because we are using that path in a health check.

This PR pins the version of SQL Server back to CU27 to get the build back to 💚 to allow us some breathing room to update properly.