### PR TITLE
Update README.md - Removed quotes from environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ steps:
       project: 'Test Project'
       runbook: 'Test Runbook'
       environments: |
-        'Dev'
-        'Test'
+        Dev
+        Test
 ```
 
 ## ✍️ Environment Variables


### PR DESCRIPTION
Environments should not be quoted, if they are Octopus will return an error, like this: There was a problem with your request. Unable to locate deployment environment(s) named ''Development''