### PR TITLE
feat: Add workflow to check for conventional commit format PR title

### DIFF
--- a/.github/workflows/conventional-commit-pr-title.yml
+++ b/.github/workflows/conventional-commit-pr-title.yml
@@ -1,0 +1,19 @@
+name: Conventional Commit PR Title
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Background 🌇 
This repository uses release please to coordinate the creation of new versions of the action, based on conventional commit prefixes (e.g. fix for a bug fix that should be released as a new patch version).

It's easy to forget to create a PR with the correct prefix and then do a squash merge with the right commit message. If you do forget you then need to create another PR with the right commit message, total footgun that most people get wrong.

## What's this? 🌵 

This PR add a workflow to check that a PR title contains a conventional commit message. It runs when a PR is opened/reopened/pushed-to or when the PR title is updated. 

The workflow is copied directly from our [`deprovision-ephemeral-environment` action repo](https://github.com/OctopusDeploy/deprovision-ephemeral-environment/blob/main/.github/workflows/conventional-commit-pr-title.yml) where this same check is already in place.

 🚩 To make this change more effective, I've also updated the repository to allow only squash merges and take the commit message for a squash merge from the PR title. 

## How to review? 🔍 
☑️ Anything I've missed??

[sc-130131]

BEGIN_COMMIT_OVERRIDE
chore: Add workflow to check for conventional commit format PR title
END_COMMIT_OVERRIDE